### PR TITLE
무신사에서 사이즈표 및 페이지 정보 가져오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,8 +55,8 @@
         "styled-component": "^2.8.0",
         "styled-reset": "^4.4.4",
         "terser-webpack-plugin": "^5.3.6",
-        "ts-loader": "^9.4.1",
-        "typescript": "^4.9.3",
+        "ts-loader": "^9.4.2",
+        "typescript": "^4.9.4",
         "webpack": "^5.75.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.11.1"
@@ -19959,9 +19959,9 @@
       "dev": true
     },
     "node_modules/ts-loader": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
-      "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
+      "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -20175,9 +20175,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -38809,9 +38809,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.1.tgz",
-      "integrity": "sha512-384TYAqGs70rn9F0VBnh6BPTfhga7yFNdC5gXbQpDrBj9/KsT4iRkGqKXhziofHOlE2j6YEaiTYVGKKvPhGWvw==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
+      "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -38971,9 +38971,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "styled-component": "^2.8.0",
     "styled-reset": "^4.4.4",
     "terser-webpack-plugin": "^5.3.6",
-    "ts-loader": "^9.4.1",
-    "typescript": "^4.9.3",
+    "ts-loader": "^9.4.2",
+    "typescript": "^4.9.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,4 +1,9 @@
+import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
+
+import { ProductType } from '../../../states';
+import { productState } from '../../../states/atom';
 
 interface ButtonProps {
   content: ContentType;
@@ -28,9 +33,31 @@ const colorMapper = (content: ContentType): ColorMapType => {
 function Button(props: ButtonProps) {
   const { content } = props;
   const { background, text } = colorMapper(content);
+  const [product, setProductState] = useRecoilState(productState);
+
+  const saveProduct = () => {
+    const productData = chrome.storage.sync.get(['product']).then(({ product: { image, productName } }) => {
+      setProductState((prev) => ({ ...prev, image, productName }));
+    });
+
+    chrome.tabs &&
+      chrome.tabs.query(
+        {
+          active: true,
+          currentWindow: true,
+        },
+        (tabs) => {
+          const { url, favIconUrl } = tabs[0];
+          if (!url || !favIconUrl) return;
+
+          setProductState((prev) => ({ ...prev, favIconUrl, productUrl: url }));
+        },
+      );
+  };
+  console.log('product > ', product);
 
   return (
-    <Root text={text} background={background}>
+    <Root text={text} background={background} onClick={saveProduct}>
       {content}
     </Root>
   );
@@ -48,4 +75,5 @@ const Root = styled.div<{ text: string; background: string }>`
   line-height: 120%;
   color: ${({ text }) => text};
   background-color: ${({ background }) => background};
+  cursor: pointer;
 `;

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import { ProductType } from '../../../states';
-import { productState } from '../../../states/atom';
+import { productState, topOrBottomState } from '../../../states/atom';
 
 interface ButtonProps {
   content: ContentType;
@@ -34,6 +34,7 @@ function Button(props: ButtonProps) {
   const { content } = props;
   const { background, text } = colorMapper(content);
   const [product, setProductState] = useRecoilState(productState);
+  const topOrBottom = useRecoilValue(topOrBottomState);
 
   const saveProduct = () => {
     const productData = chrome.storage.sync.get(['product']).then(({ product: { image, productName } }) => {
@@ -50,7 +51,12 @@ function Button(props: ButtonProps) {
           const { url, favIconUrl } = tabs[0];
           if (!url || !favIconUrl) return;
 
-          setProductState((prev) => ({ ...prev, favIconUrl, productUrl: url }));
+          setProductState((prev) => ({
+            ...prev,
+            favIconUrl,
+            productUrl: url,
+            topOrBottom: topOrBottom === 'top' ? 0 : 1,
+          }));
         },
       );
   };

--- a/src/components/size-compare/Sizes.tsx
+++ b/src/components/size-compare/Sizes.tsx
@@ -25,7 +25,7 @@ function Sizes(props: SizesProps) {
   return (
     <Styled.Root>
       {Object.entries(sizes).map(([key, size]) => (
-        <Styled.Size isTop={currentTab === 'top'}>
+        <Styled.Size isTop={currentTab === 'top'} key={key}>
           <Styled.SizeKey>{topBottomTextConverter(key as keyof typeof topBottomTextMapper)}</Styled.SizeKey>
           <Styled.SizeValue isSelfWrite={isSelfWrite ? true : false}>
             {size.toFixed(1)}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 3,
-  "name": "Onsize Chrome Extension",
+  "name": "Ownsize Chrome Extension",
   "description": "온사이즈 크롬 익스텐션",
   "options_page": "options.html",
-  "background": { "service_worker": "background.bundle.js" },
+  "background": { "service_worker": "script/background.js" },
   "action": {
     "default_popup": "popup.html",
+    "default_title": "온사이즈(Own-Size)",
     "default_icon": "icon-34.png"
   },
   "icons": {
@@ -13,14 +14,18 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*", "<all_urls>"],
-      "js": ["contentScript.bundle.js"]
+      "matches": ["https://www.musinsa.com/*"],
+      "js": ["script/sizeTableContent.js"]
     }
   ],
+  "externally_connectable": {
+    "matches": ["https://programmers.co.kr/"]
+  },
   "web_accessible_resources": [
     {
       "resources": ["icon-128.png", "icon-34.png"],
       "matches": []
     }
-  ]
+  ],
+  "permissions": ["tabs", "activeTab"]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
   "content_scripts": [
     {
       "matches": ["https://www.musinsa.com/*"],
-      "js": ["script/sizeTableContent.js"]
+      "js": ["script/sizeTableContent.js", "script/productContent.js"]
     }
   ],
   "externally_connectable": {
@@ -27,5 +27,5 @@
       "matches": []
     }
   ],
-  "permissions": ["tabs", "activeTab"]
+  "permissions": ["tabs", "activeTab", "storage"]
 }

--- a/src/pages/Content/index.ts
+++ b/src/pages/Content/index.ts
@@ -1,2 +1,0 @@
-console.log('Content script works!');
-console.log('Must reload extension for modifications to take effect.');

--- a/src/pages/Content/productContent/index.ts
+++ b/src/pages/Content/productContent/index.ts
@@ -1,0 +1,40 @@
+const productImage = document.querySelector('.product-img');
+const productTitle = document.querySelector('.product_title');
+
+let image;
+let productName;
+const mallName = '무신사( MUSINSA )';
+
+function isHTMLElement(arg: any): arg is HTMLElement {
+  return 'innerText' in arg;
+}
+
+if (isHTMLElement(productTitle)) {
+  productName = productTitle.innerText;
+}
+
+if (isHTMLElement(productImage)) {
+  const imageElement = productImage.querySelector('img');
+  if (imageElement) {
+    image = imageElement?.src;
+  }
+}
+
+// localStorage.setItem(
+//   'product',
+//   JSON.stringify({
+//     image,
+//     productName,
+//     mallName,
+//   }),
+// );
+
+chrome.storage.sync.set({
+  product: {
+    image,
+    productName,
+    mallName,
+  },
+});
+
+// console.log(localStorage.getItem('product'));

--- a/src/pages/Content/sizeTableContent/index.ts
+++ b/src/pages/Content/sizeTableContent/index.ts
@@ -1,0 +1,37 @@
+import { InfoType, SizeInfoType } from '../../../types/content';
+
+const table = document.querySelector('table');
+
+if (table) {
+  const columns = table.querySelectorAll('.item_val') as NodeListOf<HTMLElement>;
+  const sizeInfo: SizeInfoType = {};
+
+  const tbody = table.querySelector('tbody');
+  if (tbody) {
+    const sizes = [...tbody.querySelectorAll('tr')].filter((size) => !size.classList.length && !size.id);
+
+    // 사이즈 저장
+    [...sizes].forEach((size) => {
+      const infoType: InfoType = {};
+
+      // 실측 측정방식 객체로 저장
+      [...columns].forEach((column) => {
+        infoType[column.innerText] = 0;
+      });
+
+      const values = [...size.children].filter((element) => element.nodeName === 'TD') as HTMLElement[];
+      const th = size.children[0] as HTMLElement;
+      const MY = th.innerText;
+
+      Object.keys(infoType).forEach((key, index) => {
+        infoType[key] = Number(values[index].innerText);
+      });
+
+      sizeInfo[MY] = infoType;
+    });
+  }
+
+  console.log(sizeInfo);
+
+  table.style.border = '10px solid red';
+}

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -6,7 +6,7 @@ import GlobalStyle from '../../styles/global';
 import CannotLoadSize from './cannotloadsize';
 import NoSize from './nosize';
 import SizeCompare from './size-compare';
-import SizeOption from './sizeoption';
+import SizeOption from './size-option';
 
 function Popup() {
   const mySize = useRecoilValue(mySizeState);
@@ -16,6 +16,7 @@ function Popup() {
       <GlobalStyle />
       {/* <NoSize /> */}
       {mySize ? <SizeCompare isSelfWrite={true} /> : <CannotLoadSize />}
+      {/* <SizeOption /> */}
     </>
   );
 }

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 
-import { mySizeState } from '../../states/atom';
+import { mySizeState, productState } from '../../states/atom';
 import GlobalStyle from '../../styles/global';
 
 import CannotLoadSize from './cannotloadsize';
@@ -15,8 +15,8 @@ function Popup() {
     <>
       <GlobalStyle />
       {/* <NoSize /> */}
-      {mySize ? <SizeCompare isSelfWrite={true} /> : <CannotLoadSize />}
-      {/* <SizeOption /> */}
+      {/* {mySize ? <SizeCompare isSelfWrite={true} /> : <CannotLoadSize />} */}
+      <SizeOption />
     </>
   );
 }

--- a/src/pages/Popup/index.tsx
+++ b/src/pages/Popup/index.tsx
@@ -1,4 +1,5 @@
 import { render } from 'react-dom';
+
 import App from './App';
 
 render(<App />, window.document.querySelector('#app-container'));

--- a/src/pages/Popup/size-option/index.tsx
+++ b/src/pages/Popup/size-option/index.tsx
@@ -1,17 +1,18 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
-import imgTop from '../../../assets/img/top.svg';
 import imgBottom from '../../../assets/img/bottom.svg';
+import imgTop from '../../../assets/img/top.svg';
 import Button from '../../../components/common/Button';
+import Layout from '../../../components/common/Layout';
 import OptionButton from '../../../components/sizeoption/OptionButton';
 import theme from '../../../styles/theme';
-import { useState } from 'react';
 
 function SizeOption() {
   const [selectedOption, setSelectedOption] = useState<'상의' | '하의'>();
 
   return (
-    <>
+    <Layout>
       <Styled.Root>
         지금 어떤 옷을 보고 있나요?
         <Styled.OptionContainer>
@@ -30,7 +31,7 @@ function SizeOption() {
         </Styled.OptionContainer>
       </Styled.Root>
       <Button content="저장" />
-    </>
+    </Layout>
   );
 }
 

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -27,7 +27,7 @@ export const mySizeState = atom<SizeType>({
 
 export const topOrBottomState = atom<TopOrBottom>({
   key: 'topOrBottom',
-  default: 'bottom',
+  default: 'top',
   // effects_UNSTABLE: [persistAtom],
 });
 

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 
 import { SizeType } from '../components/size-compare';
 
-import { TopOrBottom } from '.';
+import { ProductType, TopOrBottom } from '.';
 
 export const mySizeState = atom<SizeType>({
   key: 'mySize',
@@ -28,5 +28,20 @@ export const mySizeState = atom<SizeType>({
 export const topOrBottomState = atom<TopOrBottom>({
   key: 'topOrBottom',
   default: 'bottom',
+  // effects_UNSTABLE: [persistAtom],
+});
+
+export const productState = atom<ProductType>({
+  key: 'product',
+  default: {
+    productUrl: '',
+    image: '',
+    mallName: '무신사(MUSINSA)',
+    productName: '',
+    isRecommend: true,
+    topOrBottom: 0,
+    favIconUrl: '',
+    size: '',
+  },
   // effects_UNSTABLE: [persistAtom],
 });

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -42,6 +42,8 @@ export const productState = atom<ProductType>({
     topOrBottom: 0,
     favIconUrl: '',
     size: '',
+    memo: null,
+    isPin: null,
   },
   // effects_UNSTABLE: [persistAtom],
 });

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -9,4 +9,6 @@ export interface ProductType {
   topOrBottom?: 0 | 1;
   favIconUrl?: string;
   size?: string;
+  memo?: string | null;
+  isPin?: boolean | null;
 }

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -1,1 +1,12 @@
 export type TopOrBottom = 'top' | 'bottom';
+
+export interface ProductType {
+  productUrl?: string;
+  image?: string;
+  mallName?: string;
+  productName?: string;
+  isRecommend?: boolean;
+  topOrBottom?: 0 | 1;
+  favIconUrl?: string;
+  size?: string;
+}

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -1,0 +1,7 @@
+export interface InfoType {
+  [key: string]: number;
+}
+
+export interface SizeInfoType {
+  [key: string]: InfoType;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["react/next", "react-dom/next", "chrome"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,34 +1,30 @@
-var webpack = require('webpack'),
+const webpack = require('webpack'),
   path = require('path'),
-  fileSystem = require('fs-extra'),
   env = require('./utils/env'),
   CopyWebpackPlugin = require('copy-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   TerserPlugin = require('terser-webpack-plugin');
-var { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const ASSET_PATH = process.env.ASSET_PATH || '/';
 
-var alias = {
-  'react-dom': '@hot-loader/react-dom',
-};
+// const alias = {
+//   'react-dom': '@hot-loader/react-dom',
+// };
 
-// load the secrets
-var secretsPath = path.join(__dirname, 'secrets.' + env.NODE_ENV + '.js');
+const getAbsolutePath = (pathDir) => path.resolve(__dirname, pathDir);
 
-var fileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'eot', 'otf', 'svg', 'ttf', 'woff', 'woff2'];
+const fileExtensions = ['jpg', 'jpeg', 'png', 'gif', 'eot', 'otf', 'svg', 'ttf', 'woff', 'woff2'];
 
-if (fileSystem.existsSync(secretsPath)) {
-  alias['secrets'] = secretsPath;
-}
-
-var options = {
+const options = {
   mode: process.env.NODE_ENV || 'development',
   entry: {
     options: path.join(__dirname, 'src', 'pages', 'Options', 'index.tsx'),
     popup: path.join(__dirname, 'src', 'pages', 'Popup', 'index.tsx'),
     background: path.join(__dirname, 'src', 'pages', 'Background', 'index.ts'),
     sizeTableContent: path.join(__dirname, 'src', 'pages', 'Content', 'sizeTableContent', 'index.ts'),
+    productContent: path.join(__dirname, 'src', 'pages', 'Content', 'productContent', 'index.ts'),
+    // injectContent: path.join(__dirname, 'src', 'pages', 'Content', 'injectContent', 'index.tsx'),
   },
   output: {
     filename: 'script/[name].js',
@@ -89,7 +85,10 @@ var options = {
     ],
   },
   resolve: {
-    alias: alias,
+    alias: {
+      '@src': getAbsolutePath('./src'),
+      '@assets': getAbsolutePath('./assets'),
+    },
     extensions: fileExtensions.map((extension) => '.' + extension).concat(['.js', '.jsx', '.ts', '.tsx', '.css']),
   },
   plugins: [
@@ -102,7 +101,7 @@ var options = {
       verbose: true,
     }),
     new webpack.ProgressPlugin(),
-    // expose and write the allowed env vars on the compiled bundle
+    // expose and write the allowed env consts on the compiled bundle
     new webpack.EnvironmentPlugin(['NODE_ENV']),
     new CopyWebpackPlugin({
       patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,10 +28,10 @@ var options = {
     options: path.join(__dirname, 'src', 'pages', 'Options', 'index.tsx'),
     popup: path.join(__dirname, 'src', 'pages', 'Popup', 'index.tsx'),
     background: path.join(__dirname, 'src', 'pages', 'Background', 'index.ts'),
-    contentScript: path.join(__dirname, 'src', 'pages', 'Content', 'index.ts'),
+    sizeTableContent: path.join(__dirname, 'src', 'pages', 'Content', 'sizeTableContent', 'index.ts'),
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: 'script/[name].js',
     path: path.resolve(__dirname, 'build'),
     clean: true,
     publicPath: ASSET_PATH,


### PR DESCRIPTION
## 이슈 넘버
- close #9 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 무신사에서 사이즈표 가져오기 
- [x] 서버 기능명세서에서 요구하는 body 값 recoil 이용해서 세팅 > 저장 버튼 누르면 콘솔 찍힘
![image](https://user-images.githubusercontent.com/66051416/211148525-de3ac938-76ad-45f2-8a36-84054ddaa36d.png)
![image](https://user-images.githubusercontent.com/66051416/211148587-25d58cc1-eb2f-400b-a295-39d78947414e.png)



## Need Review
- 바닐라 자바스크립트로 dom에 접근하니까 코드가 뭔가 이쁘진 않지만 돌아가는 스레기를 만들어봤어요
- `memo`, `isPin` 속성은 웹 페이지에서 할 수 있는 기능인데 서버에서 요 두 프로퍼티도 써달라고 요청해서 익스텐션에서는 null이 들어가도록 구현했어요.
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
