### PR TITLE
재로그인, 새로고침, 탭 간 이동 시 익스텐션 리프레시

### DIFF
--- a/src/assets/img/skeleton.svg
+++ b/src/assets/img/skeleton.svg
@@ -1,0 +1,3 @@
+<svg width="111" height="111" viewBox="0 0 111 111" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.721191" y="0.649414" width="110" height="110" fill="#D9D9D9"/>
+</svg>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,16 +31,6 @@
       "js": ["script/getUserData.js"]
     }
   ],
-  "externally_connectable": {
-    "matches": [
-      "https://www.musinsa.com/*/goods/*",
-      "https://www.mrporter.com/*/product/*",
-      "https://www.ssense.com/*/product/*",
-      "https://www.okmall.com/products/*",
-      "https://product.29cm.co.kr/*",
-      "https://www.wconcept.co.kr/Product/*"
-    ]
-  },
   "web_accessible_resources": [
     {
       "resources": ["icon16.png", "icon32.png", "icon48.png"],
@@ -48,12 +38,14 @@
     }
   ],
   "host_permissions": [
+    "https://ownsize.me/*",
     "https://www.musinsa.com/*/goods/*",
     "https://www.mrporter.com/*/product/*",
     "https://www.ssense.com/*/product/*",
     "https://www.okmall.com/products/*",
     "https://product.29cm.co.kr/*",
-    "https://www.wconcept.co.kr/Product/*"
+    "https://www.wconcept.co.kr/Product/*",
+    "<all_urls>"
   ],
-  "permissions": ["activeTab", "storage", "scripting", "tabs"]
+  "permissions": ["activeTab", "storage", "scripting", "tabs", "<all_urls>"]
 }

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -1,3 +1,29 @@
-chrome.tabs.onUpdated.addListener((tabs) => {
-  chrome.scripting.executeScript({ target: { tabId: tabs }, files: ['/script/productContent.js'] });
-});
+const matchList = [
+  'https://www.musinsa.com',
+  'https://www.mrporter.com',
+  'https://www.ssense.com',
+  'https://www.okmall.com',
+  'https://product.29cm.co.kr',
+  'https://www.wconcept.co.kr',
+];
+
+function listener() {
+  chrome.tabs.onUpdated.addListener((tabs) => {
+    chrome.tabs.query({ active: true }, (tab) => {
+      const url = tab[0].url;
+      if (!url) return;
+      if (url.includes('ownsize.me')) {
+        chrome.scripting.executeScript({ target: { tabId: tabs }, files: ['/script/getUserData.js'] });
+        console.log('getUserData script reload');
+      }
+
+      if (matchList.some((v) => url.includes(v))) {
+        chrome.scripting.executeScript({ target: { tabId: tabs }, files: ['/script/productContent.js'] }).then(() => {
+          console.log('productContent script reload');
+        });
+      }
+    });
+  });
+}
+listener();
+chrome.tabs.onUpdated.removeListener(listener);

--- a/src/pages/Content/sizeTableContent/index.ts
+++ b/src/pages/Content/sizeTableContent/index.ts
@@ -33,13 +33,15 @@ if (table) {
   const tbody = table.querySelector('tbody');
   if (tbody) {
     const sizes = [...tbody.querySelectorAll('tr')].filter((size) => !size.classList.length && !size.id);
+    const ignore = new Set();
+    const keyOrder: string[] = [];
 
     // 사이즈 저장
     [...sizes].forEach((size) => {
       const infoType: InfoType = {};
 
       // 실측 측정방식 객체로 저장
-      [...columns].forEach((column) => {
+      [...columns].forEach((column, idx) => {
         // 한글 key값 영어로 변환
         let innerText = column.innerText as keyof typeof textMapper;
         if (innerText.includes('단면')) {
@@ -50,14 +52,21 @@ if (table) {
         }
 
         const key = textMapper[innerText];
-        if (!key) return;
+        if (!key) {
+          ignore.add(idx);
+          return;
+        }
         infoType[key] = 0;
+        keyOrder.push(key);
       });
 
       const values = [...size.children].filter((element) => element.nodeName === 'TD') as HTMLElement[];
 
-      Object.keys(infoType).forEach((key, index) => {
-        if (values[index]) infoType[key] = Number(values[index].innerText);
+      let i = 0;
+      values.forEach((value, index) => {
+        if (value && !ignore.has(index)) {
+          infoType[keyOrder[i++]] = Number(values[index].innerText);
+        }
       });
 
       const th = size.children[0] as HTMLElement;
@@ -70,6 +79,7 @@ if (table) {
       infoType['size'] = MY;
 
       sizeTable = [...sizeTable, infoType];
+      console.log(infoType);
     });
   }
 }

--- a/src/pages/Popup/Popup.tsx
+++ b/src/pages/Popup/Popup.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { useRedirect } from '../../hooks/queries/useRedirect';
 import { CurrentViewType } from '../../states';
 import { currentViewState } from '../../states/atom';
-import GlobalStyle from '../../styles/global';
 
 import CannotLoadSize from './cannotloadsize';
 import First from './first';
@@ -23,9 +22,16 @@ function Popup() {
   const checkCurrentView = async () => {
     const { sizeTable } = await chrome.storage.local.get(['sizeTable']);
 
-    sizeTable
-      ? setCurrentView((localStorage.getItem('currentView') as CurrentViewType) || 'size-option')
-      : setCurrentView('cannotload');
+    if (sizeTable) {
+      const storedCurrentView = localStorage.getItem('currentView') as CurrentViewType;
+      if (storedCurrentView === 'cannotload') {
+        setCurrentView('size-option');
+      } else {
+        setCurrentView(storedCurrentView || 'size-option');
+      }
+    } else {
+      setCurrentView('cannotload');
+    }
   };
 
   useEffect(() => {

--- a/src/pages/Popup/save-product/index.tsx
+++ b/src/pages/Popup/save-product/index.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import skeleton from '../../../assets/img/skeleton.svg';
 import Layout from '../../../components/common/Layout';
 import Main from '../../../components/common/Main';
 import SizeRecommendButton from '../../../components/save-product/SizeRecommendButton';
@@ -11,16 +13,27 @@ import theme from '../../../styles/theme';
 
 function SaveProduct() {
   const sizeRecommend = useRecoilValue(sizeRecommendState);
+  const { image } = useRecoilValue(productState);
+  const storageImage = localStorage.getItem('productImage');
+  const [isLoading, setIsLoading] = useState(true);
 
   const getLink = <Styled.Link onClick={() => window.open(DOMAIN.HOME)}>{LINK.SAVE}</Styled.Link>;
-  const { image } = useRecoilValue(productState);
-  const storageItem = localStorage.getItem('productImage');
 
   const noRecommendedSize = !sizeRecommend || sizeRecommend === 'nosize';
   return (
     <Layout close>
       <Main
-        image={<Styled.Image src={storageItem || image} />}
+        image={
+          <Styled.Image
+            width="110"
+            height="110"
+            src={isLoading ? skeleton : storageImage || image}
+            alt="저장한 상품"
+            loading="lazy"
+            data-src={isLoading ? skeleton : storageImage || image}
+            onLoad={() => setIsLoading(false)}
+          />
+        }
         content={MESSAGE.SAVE_MY_CLOSET}
         link={getLink}
         noPadding

--- a/src/pages/Popup/size-compare/index.tsx
+++ b/src/pages/Popup/size-compare/index.tsx
@@ -29,6 +29,7 @@ function SizeCompare() {
   // 마이사이즈 조회
   const getMySize = async () => {
     const { top, bottom } = await fetchMySize();
+    console.log(top, bottom);
 
     localStorage.setItem('topSize', JSON.stringify(top));
     localStorage.setItem('bottomSize', JSON.stringify(bottom));


### PR DESCRIPTION
## 이슈 넘버
- close #41 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 🤔 세션이 만료된 후 다시 로그인했을 때 익스텐션 로컬스토리지 데이터가 refresh되지 않아 여전히 세션이 만료됐다는 alert가 뜨곤 했습니다. 
🔽
이를 해결하기 위해 쇼핑몰, 온사이즈 웹사이트에 해당하는 url에 접근했을 때 onActivated, onUpdated 이벤트가 발생하면, 유저 정보를 불러오는 `getUserData`, 사이즈표를 긁어오는 `sizeTableContent`, 쇼핑몰 url과 상품 이미지 등을 불러오는 `productContent` contents script들을 모두 ✅재호출✅ 시켜주도록 background.ts를 수정했습니다.
- [x] 🤔 무신사 하의 사이즈표에 간혹 '엉덩이단면' 컬럼이 존재하는데 mapper에 존재하지 않는 key값은 건너뛰도록 코드를 짰더니 💦허벅지 사이즈에 엉덩이 사이즈가 들어가는💦 문제가 있었습니다. 
🔽
mapper에 포함되지 않는 key값의 인덱스를 담을 `ignore` 배열을 추가해서 해당 인덱스는 사이즈표 데이터에 추가하지 않도록 수정했습니다.
- [x] 🤔 익스텐션 헤더의 x 버튼을 누르지 않고 팝업 영역 바깥을 클릭하거나 익스텐션 아이콘을 눌러 창을 닫는 경우에는 로컬 스토리지에 히스토리를 저장해서 다시 창을 켰을 때 이전에 보던 뷰가 나오도록 되어있어요. 
기존의 코드는 사이즈표가 없는 웹페이지를 보면 `cannotload` 뷰가 렌더링되고, 사이즈표가 있는 상품페이지로 넘어가도 localStorage에 남아있는 데이터를 그대로 가져와서 사이즈표가 있음에도 cannotload를 표시했어요.
🔽
조건문을 추가해서 사이즈표가 있을 때 localStorage의 currentView 데이터가 cannotload라면 size-option 뷰로 바꾸도록 수정했습니다.


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

이와중에 NaN이 뜨는 것이 있네요! ㅎㅎ 
https://user-images.githubusercontent.com/66051416/220069843-065782e2-fdcf-4b1f-95f7-3050465f28be.mp4



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
