### PR TITLE
최종 QA 반영

### DIFF
--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -26,6 +26,7 @@ function Header(props: HeaderProps) {
       'history',
       'isSelfWrite',
       'productSizes',
+      'topOrBottom',
     );
     window.close();
   };

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,9 +1,11 @@
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import icBack from '../../../assets/icons/back.svg';
 import icClose from '../../../assets/icons/close.svg';
 import { useRemoveLocalStorage } from '../../../hooks/queries/useRemoveLocalStorage';
 import { useGoBackToHistory } from '../../../hooks/ui/useGoBackToHistory';
+import { currentViewState, isSelfWriteState } from '../../../states/atom';
 import theme from '../../../styles/theme';
 
 interface HeaderProps {
@@ -16,6 +18,8 @@ function Header(props: HeaderProps) {
   const { back, title, close } = props;
   const { goBackToHistory } = useGoBackToHistory();
   const { removeLocalStorageItem } = useRemoveLocalStorage();
+  const currentView = useRecoilValue(currentViewState);
+  const isSelfWrite = useRecoilValue(isSelfWriteState);
 
   const reset = () => {
     removeLocalStorageItem(
@@ -34,7 +38,7 @@ function Header(props: HeaderProps) {
   return (
     <Styled.Root>
       <Styled.Back>{back && <img src={icBack} alt="back" onClick={goBackToHistory} />}</Styled.Back>
-      <Styled.Title>{title || null}</Styled.Title>
+      <Styled.Title hasMargin={currentView === 'compare' && isSelfWrite}>{title || null}</Styled.Title>
       <Styled.Close>{close && <img src={icClose} alt="close" onClick={reset} />}</Styled.Close>
     </Styled.Root>
   );
@@ -61,9 +65,10 @@ const Styled = {
       cursor: pointer;
     }
   `,
-  Title: styled.h1`
+  Title: styled.h1<{ hasMargin: boolean }>`
     ${theme.fonts.title1}
     color: ${theme.colors.black};
+    margin-top: ${({ hasMargin }) => hasMargin && '2.77rem'};
   `,
   Close: styled.div`
     width: 2.4rem;

--- a/src/components/size-compare/SelfWriteCompare.tsx
+++ b/src/components/size-compare/SelfWriteCompare.tsx
@@ -33,7 +33,7 @@ const Styled = {
   Root: styled.div<{ isTop: boolean }>`
     display: flex;
     justify-content: center;
-    padding-top: ${({ isTop }) => (isTop ? '7.4rem' : '3rem')};
-    margin-bottom: ${({ isTop }) => (isTop ? '7.3rem' : '3.4rem')};
+    padding-top: ${({ isTop }) => (isTop ? '6.95rem' : '3rem')};
+    margin-bottom: ${({ isTop }) => (isTop ? '6.95rem' : '3.4rem')};
   `,
 };

--- a/src/components/size-compare/Sizes.tsx
+++ b/src/components/size-compare/Sizes.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { topBottomTextConverter, topBottomTextMapper } from '../../../utils/topBottomTextMapper';
 import { TopOrBottom } from '../../states';
-import { isSelfWriteState } from '../../states/atom';
+import { isSelfWriteState, measureState } from '../../states/atom';
 import theme from '../../styles/theme';
 
 import { BottomType, SizePropType, TopType } from '.';
@@ -17,6 +17,7 @@ interface SizesProps {
 function Sizes(props: SizesProps) {
   const { sizes, productSizes, currentTab } = props;
   const isSelfWrite = useRecoilValue(isSelfWriteState);
+  const measure = useRecoilValue(measureState);
 
   const calculateDifference = (key: keyof SizePropType, size: number) => {
     if (!productSizes) return;
@@ -24,11 +25,20 @@ function Sizes(props: SizesProps) {
     return size > compareTarget ? `-${(size - compareTarget).toFixed(1)}` : `+${(compareTarget - size).toFixed(1)}`;
   };
 
+  const getMeasure = () => {
+    if (currentTab === 'top') {
+      return measure.top ? '단면' : '둘레';
+    }
+    return measure.bottom ? '단면' : '둘레';
+  };
+
   return (
     <Styled.Root>
       {Object.entries(sizes).map(([key, size]) => (
         <Styled.Size isTop={currentTab === 'top'} key={key}>
-          <Styled.SizeKey>{topBottomTextConverter(key as keyof typeof topBottomTextMapper)}</Styled.SizeKey>
+          <Styled.SizeKey>
+            {topBottomTextConverter(key as keyof typeof topBottomTextMapper, getMeasure())}
+          </Styled.SizeKey>
           <Styled.SizeValue isSelfWrite={isSelfWrite ? true : false}>
             {size.toFixed(1)}
             <span>cm</span>

--- a/src/hooks/queries/useSizeRecommend.ts
+++ b/src/hooks/queries/useSizeRecommend.ts
@@ -116,6 +116,8 @@ export const useSizeRecommend = () => {
     }
     setSelectedOption(option);
     setTopOrBottom(option);
+    console.log(option);
+    localStorage.setItem('topOrBottom', option);
   };
 
   const executeSizeRecommmend = async (option: TopOrBottom) => {

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -2,7 +2,7 @@ const matchList = [
   'https://www.musinsa.com/[a-zA-Z]*/goods/[a-zA-Z]*',
   'https://www.mrporter.com/.*/[a-zA-Z]*/product/[a-zA-Z]*',
   'https://www.ssense.com/.*/[a-zA-Z]*/product/[a-zA-Z]*',
-  'https://www.okmall.com/products/[a-zA-Z]*',
+  'https://www.okmall.com/products/view?.*',
   'https://product.29cm.co.kr/[a-zA-Z]*',
   'https://www.wconcept.co.kr/Product/[a-zA-Z]*',
 ];

--- a/src/pages/Popup/size-compare/index.tsx
+++ b/src/pages/Popup/size-compare/index.tsx
@@ -14,7 +14,7 @@ import Tabs from '../../../components/size-compare/Tabs';
 import { DOMAIN } from '../../../contants/domain';
 import { LINK, MESSAGE } from '../../../contants/text';
 import useTabs from '../../../hooks/ui/useTabs';
-import { isSelfWriteState, mySizeState, productSelfWriteState } from '../../../states/atom';
+import { isSelfWriteState, measureState, mySizeState, productSelfWriteState } from '../../../states/atom';
 import theme from '../../../styles/theme';
 
 function SizeCompare() {
@@ -22,6 +22,7 @@ function SizeCompare() {
   const [mySize, setMySize] = useRecoilState(mySizeState);
   const isSelfWrite = useRecoilValue(isSelfWriteState);
   const productSelfWrite = useRecoilValue(productSelfWriteState);
+  const [, setMeasure] = useRecoilState(measureState);
   const [isLoading, setIsLoading] = useState(true);
 
   const { currentTab = 'top', handleTab } = useTabs();
@@ -82,6 +83,7 @@ function SizeCompare() {
     localStorage.setItem('topSize', JSON.stringify(top));
     localStorage.setItem('bottomSize', JSON.stringify(bottom));
     setMySize({ top, bottom });
+    setMeasure({ top: top.isWidthOfTop, bottom: bottom.isWidthOfBottom });
   };
 
   const isEmptyData = (data: object) => {

--- a/src/pages/Popup/size-write/index.tsx
+++ b/src/pages/Popup/size-write/index.tsx
@@ -53,7 +53,7 @@ function SizeWrite() {
     isAddRow,
     setIsAddRow,
   } = useForm({
-    initialValues: topOrBottom === 'top' ? TopInitValues : BottomInitValues,
+    initialValues: topOrBottom === 'top' || topOrBottom === null ? TopInitValues : BottomInitValues,
     onSubmit: async (values) => {
       const sizes: SizeTableType[] = [];
       const inputData: SizeTableType = {

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -66,7 +66,7 @@ export const productSelfWriteState = atom<SizeTableType>({
 
 export const topOrBottomState = atom<TopOrBottom>({
   key: 'topOrBottom',
-  default: 'top',
+  default: (localStorage.getItem('topOrBottom') as TopOrBottom) || null,
 });
 
 export const productState = atom<ProductType>({

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 import { SizeType } from '../components/size-compare';
 import { SizeTableType } from '../types/remote';
 
-import { CurrentViewType, ProductType, TopOrBottom, UserDataType } from '.';
+import { CurrentViewType, MeasureType, ProductType, TopOrBottom, UserDataType } from '.';
 
 export const mySizeState = atom<SizeType>({
   key: 'mySize',
@@ -112,4 +112,12 @@ export const userDataState = atom<UserDataType>({
 export const sizeRecommendState = atom<string | null>({
   key: 'size-recommend',
   default: localStorage.getItem('recommend-size') || null,
+});
+
+export const measureState = atom<MeasureType>({
+  key: 'measure',
+  default: {
+    top: true,
+    bottom: true,
+  },
 });

--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -31,3 +31,8 @@ export interface UserDataType {
   userId: number;
   token: string;
 }
+
+export interface MeasureType {
+  top: boolean;
+  bottom: boolean;
+}

--- a/utils/topBottomTextMapper.ts
+++ b/utils/topBottomTextMapper.ts
@@ -9,12 +9,15 @@ export const topBottomTextMapper = {
   hem: '밑단 ',
 };
 
-const measureCheckList = ['shoulder', 'chest', 'waist', 'thigh', 'hem'];
+const measureCheckList = ['chest', 'waist', 'thigh', 'hem'];
 
 export const topBottomTextConverter = (key: keyof typeof topBottomTextMapper, measure: string) => {
+  if (key === 'shoulder') {
+    const text = topBottomTextMapper[key] + '너비';
+    return text;
+  }
   if (measureCheckList.includes(key)) {
     const text = topBottomTextMapper[key] + measure;
-    console.log(key, text);
     return text;
   }
   return topBottomTextMapper[key];

--- a/utils/topBottomTextMapper.ts
+++ b/utils/topBottomTextMapper.ts
@@ -1,14 +1,21 @@
 export const topBottomTextMapper = {
   topLength: '총장',
-  shoulder: '어깨 단면',
-  chest: '가슴 단면',
+  shoulder: '어깨 ',
+  chest: '가슴 ',
   bottomLength: '총장',
-  waist: '허리',
-  thigh: '허벅지',
+  waist: '허리 ',
+  thigh: '허벅지 ',
   rise: '밑위',
-  hem: '밑단',
+  hem: '밑단 ',
 };
 
-export const topBottomTextConverter = (key: keyof typeof topBottomTextMapper) => {
+const measureCheckList = ['shoulder', 'chest', 'waist', 'thigh', 'hem'];
+
+export const topBottomTextConverter = (key: keyof typeof topBottomTextMapper, measure: string) => {
+  if (measureCheckList.includes(key)) {
+    const text = topBottomTextMapper[key] + measure;
+    console.log(key, text);
+    return text;
+  }
   return topBottomTextMapper[key];
 };


### PR DESCRIPTION
## 이슈 넘버
- close #47 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 사이즈 직접 입력하기 클릭 시 → 상의/하의 선택 뷰 생략 후 상의 수동입력 뷰가 자동으로 발생 -> topOrBottom default 값 수정
- [x] 사이즈 수동 입력 → 한 개만 입력 → 사이즈 비교해주는 뷰에서 상단 텍스트가 위로 밀리는 이슈 수정
- [x] 사이즈 비교 뷰 단면 / 둘레 텍스트 및 사이즈값 수정
- [x] 오케이몰 전체 옷 보이는 뷰에서 익스텐션 활성화 시 최상단에 있는 의류 이미지 및 이름이 저장됨 -> 해당 url 접근 시 익스텐션 비활성화


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
