### PR TITLE
수동입력 단면둘레 오류

### DIFF
--- a/src/hooks/business/useForm.ts
+++ b/src/hooks/business/useForm.ts
@@ -1,17 +1,51 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { TopOrBottom } from '../../states';
+import { topOrBottomState } from '../../states/atom';
 import { ValuesType } from '../../types/useForm';
 
 interface FormProps {
+  measure: '단면' | '둘레';
   initialValues: ValuesType;
   onSubmit: (values: object) => void;
 }
 
-function useForm({ initialValues, onSubmit }: FormProps) {
+function useForm(props: FormProps) {
+  const topOrBottom = useRecoilValue(topOrBottomState);
+  const { measure, initialValues, onSubmit } = props;
   const [values, setValues] = useState<ValuesType>(initialValues);
   const [addedValues, setAddedValues] = useState<ValuesType>(initialValues);
   const [isAddRow, setIsAddRow] = useState<TopOrBottom | null>(null);
+
+  useEffect(() => {
+    if (topOrBottom === 'top') {
+      setValues({
+        ...values,
+        shoulder: `${
+          measure === '둘레'
+            ? (parseFloat(values.shoulder) * 2).toFixed(1)
+            : (parseFloat(values.shoulder) / 2).toFixed(1)
+        }`,
+        chest: `${
+          measure === '둘레' ? (parseFloat(values.chest) * 2).toFixed(1) : (parseFloat(values.chest) / 2).toFixed(1)
+        }`,
+      });
+      setAddedValues({
+        ...addedValues,
+        shoulder: `${
+          measure === '둘레'
+            ? (parseFloat(addedValues.shoulder) * 2).toFixed(1)
+            : (parseFloat(addedValues.shoulder) / 2).toFixed(1)
+        }`,
+        chest: `${
+          measure === '둘레'
+            ? (parseFloat(addedValues.chest) * 2).toFixed(1)
+            : (parseFloat(addedValues.chest) / 2).toFixed(1)
+        }`,
+      });
+    }
+  }, [measure]);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;

--- a/src/hooks/business/useForm.ts
+++ b/src/hooks/business/useForm.ts
@@ -22,30 +22,20 @@ function useForm(props: FormProps) {
     if (topOrBottom === 'top') {
       setValues({
         ...values,
-        shoulder: `${
-          measure === '둘레'
-            ? (parseFloat(values.shoulder) * 2).toFixed(1)
-            : (parseFloat(values.shoulder) / 2).toFixed(1)
-        }`,
-        chest: `${
-          measure === '둘레' ? (parseFloat(values.chest) * 2).toFixed(1) : (parseFloat(values.chest) / 2).toFixed(1)
-        }`,
+        shoulder: measureConverter(values.shoulder),
+        chest: measureConverter(values.chest),
       });
       setAddedValues({
         ...addedValues,
-        shoulder: `${
-          measure === '둘레'
-            ? (parseFloat(addedValues.shoulder) * 2).toFixed(1)
-            : (parseFloat(addedValues.shoulder) / 2).toFixed(1)
-        }`,
-        chest: `${
-          measure === '둘레'
-            ? (parseFloat(addedValues.chest) * 2).toFixed(1)
-            : (parseFloat(addedValues.chest) / 2).toFixed(1)
-        }`,
+        shoulder: measureConverter(addedValues.shoulder),
+        chest: measureConverter(addedValues.chest),
       });
     }
   }, [measure]);
+
+  const measureConverter = (value: string) => {
+    return `${measure === '둘레' ? (parseFloat(value) * 2).toFixed(1) : (parseFloat(value) / 2).toFixed(1)}`;
+  };
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;

--- a/src/hooks/business/useForm.ts
+++ b/src/hooks/business/useForm.ts
@@ -30,6 +30,19 @@ function useForm(props: FormProps) {
         shoulder: measureConverter(addedValues.shoulder),
         chest: measureConverter(addedValues.chest),
       });
+    } else {
+      setValues({
+        ...values,
+        waist: measureConverter(values.waist),
+        thigh: measureConverter(values.thigh),
+        hem: measureConverter(values.hem),
+      });
+      setAddedValues({
+        ...addedValues,
+        waist: measureConverter(addedValues.waist),
+        thigh: measureConverter(addedValues.thigh),
+        hem: measureConverter(addedValues.hem),
+      });
     }
   }, [measure]);
 

--- a/src/pages/Popup/size-write/index.tsx
+++ b/src/pages/Popup/size-write/index.tsx
@@ -36,7 +36,7 @@ const BottomInitValues: BottomValuesType = { size: '', bottomLength: '', waist: 
 
 function SizeWrite() {
   const topOrBottom = useRecoilValue(topOrBottomState);
-  const [measure, setMeasure] = useState('단면');
+  const [measure, setMeasure] = useState<'단면' | '둘레'>('단면');
   const [, setCurrentView] = useRecoilState(currentViewState);
   const [, setProductSize] = useRecoilState(productSelfWriteState);
   const { onClickOption: handleSizeRecommend } = useSizeCompare();
@@ -53,6 +53,7 @@ function SizeWrite() {
     isAddRow,
     setIsAddRow,
   } = useForm({
+    measure,
     initialValues: topOrBottom === 'top' ? TopInitValues : BottomInitValues,
     onSubmit: async (values) => {
       const sizes: SizeTableType[] = [];
@@ -93,7 +94,8 @@ function SizeWrite() {
         if (inputKey === 'size') {
           inputData.size = inputValue;
         } else {
-          inputData[inputKey] = parseFloat(inputValue);
+          const value = measure === '둘레' ? inputValue * 2 : inputValue;
+          inputData[inputKey] = parseFloat(value);
         }
       });
 


### PR DESCRIPTION
## 이슈 넘버
- close #48 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 수동입력 단면둘레 전환시 값*2 되어야함


## Need Review
- useForm 내에 measure를 전달하고 useEffect로 measure를 감시해서 고쳐주었습니다.
- 보다 간결한 코드를 위해 값을 전환해주는 함수를 만들어 사용했습니다.
```tsx
useEffect(() => {
    if (topOrBottom === 'top') {
      setValues({
        ...values,
        shoulder: measureConverter(values.shoulder),
        chest: measureConverter(values.chest),
      });
      setAddedValues({
        ...addedValues,
        shoulder: measureConverter(addedValues.shoulder),
        chest: measureConverter(addedValues.chest),
      });
    } else {
      setValues({
        ...values,
        waist: measureConverter(values.waist),
        thigh: measureConverter(values.thigh),
        hem: measureConverter(values.hem),
      });
      setAddedValues({
        ...addedValues,
        waist: measureConverter(addedValues.waist),
        thigh: measureConverter(addedValues.thigh),
        hem: measureConverter(addedValues.hem),
      });
    }
  }, [measure]);

const measureConverter = (value: string) => {
    return `${measure === '둘레' ? (parseFloat(value) * 2).toFixed(1) : (parseFloat(value) / 2).toFixed(1)}`;
  };
```

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
