### PR TITLE
익스텐션 설치 페이지에서 아이콘 활성화, 사이즈 추천 로직 수정

### DIFF
--- a/src/hooks/queries/useSizeRecommend.ts
+++ b/src/hooks/queries/useSizeRecommend.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { postSizeTable, saveResult } from '../../apis/api';
+import { fetchMySize, postSizeTable, saveResult } from '../../apis/api';
 import { TopOrBottom } from '../../states';
 import {
   currentViewState,
@@ -120,21 +120,35 @@ export const useSizeRecommend = () => {
   };
 
   const executeSizeRecommmend = async (option: TopOrBottom) => {
-    setCurrentView('loading');
-
     await sizeCrawling(option);
     await getSizeRecommendResult(option);
     renderNextView();
   };
 
+  const isEmptyData = (data: object) => {
+    return Object.values(data).every((value) => value === null);
+  };
+
+  const checkMySizeExist = async (option: TopOrBottom) => {
+    const { top, bottom } = await fetchMySize();
+
+    if (option === 'top') {
+      isEmptyData(top) ? setCurrentView('nosize') : executeSizeRecommmend('top');
+    } else {
+      isEmptyData(bottom) ? setCurrentView('nosize') : executeSizeRecommmend('bottom');
+    }
+  };
+
   const onClickOption = (option: TopOrBottom) => {
+    setCurrentView('loading');
+
     checkOption(option);
 
     if (isSelfWrite) {
       setCurrentView('size-write');
       return;
     }
-    executeSizeRecommmend(option);
+    checkMySizeExist(option);
   };
 
   return { onClickOption };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
   "action": {
     "default_popup": "popup.html",
     "default_title": "온사이즈(Own-Size)",
-    "default_icon": "assets/img/icon-inactive.png"
+    "default_icon": "assets/img/icon32.png"
   },
   "icons": {
     "16": "assets/img/icon16.png",

--- a/src/pages/Background/index.ts
+++ b/src/pages/Background/index.ts
@@ -7,7 +7,7 @@ const matchList = [
   'https://www.wconcept.co.kr/Product/[a-zA-Z]*',
 ];
 
-const extensionUrl = 'chrome://extensions/';
+const webstoreUrl = 'https://chrome.google.com/webstore';
 const websiteUrl = 'ownsize.me';
 
 const reloadUserData = (tabId: number) => {
@@ -41,7 +41,7 @@ const checkUrl = (url: string, tabId: number) => {
     reloadUserData(tabId);
   }
 
-  if (url.includes(extensionUrl)) {
+  if (url.includes(webstoreUrl)) {
     activate();
     return;
   }


### PR DESCRIPTION
## 이슈 넘버
- close #51 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 익스텐션 설치 페이지에서 아이콘 활성화  👉 개발자 모드 확장 프로그램 url에서 유저가 직접 설치받는 크롬 웹스토어 url로 수정
- [x] `useSizeRecommend` hook에서 마이사이즈 상or하의 데이터가 존재하면 사이즈 추천 함수 실행, 존재하지 않으면 `nosize` 뷰를 바로 띄우도록 변경 


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
- 빌드파일 TL에게 제출했습니다

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
