### PR TITLE
fix/#56: 알맞은 사이즈가 없을 때 저장 버튼 클릭 시 nosize로 들어가는 이슈 해결

### DIFF
--- a/src/components/size-compare/Sizes.tsx
+++ b/src/components/size-compare/Sizes.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { topBottomTextConverter, topBottomTextMapper } from '../../../utils/topBottomTextMapper';
 import { TopOrBottom } from '../../states';
-import { isSelfWriteState, measureState } from '../../states/atom';
+import { isSelfWriteState, measureState, mySizeState } from '../../states/atom';
 import theme from '../../styles/theme';
 
 import { BottomType, SizePropType, TopType } from '.';
@@ -17,24 +17,74 @@ function Sizes(props: SizesProps) {
   const { sizes, productSizes, currentTab } = props;
   const isSelfWrite = useRecoilValue(isSelfWriteState);
   const measure = useRecoilValue(measureState);
+  const mySize = useRecoilValue(mySizeState);
 
   const calculateDifference = (key: keyof SizePropType, size: number) => {
     if (!productSizes) return;
-    const compareTarget = (productSizes[key] as unknown as number) || 0;
-    return size > compareTarget ? `-${(size - compareTarget).toFixed(1)}` : `+${(compareTarget - size).toFixed(1)}`;
+    console.log(key, size, productSizes[key]);
+    let compareTarget = (productSizes[key] as unknown as number) || 0;
+    let updatedSize = size;
+    const { isWidthOfTop } = mySize.top;
+    const { isWidthOfBottom } = mySize.bottom;
+    const ignore = ['topLength', 'bottomLength', 'rise'];
+    if (ignore.includes(key)) {
+      return updatedSize > compareTarget
+        ? `-${(updatedSize - compareTarget).toFixed(1)}`
+        : `+${(compareTarget - updatedSize).toFixed(1)}`;
+    }
+
+    if (isSelfWrite) {
+      if (currentTab === 'top') {
+        const [newSize, newProductSize] = checkMeasure(size, compareTarget, isWidthOfTop as boolean, measure.selfTop);
+        updatedSize = newSize;
+        compareTarget = newProductSize;
+      } else {
+        const [newSize, newProductSize] = checkMeasure(
+          size,
+          compareTarget,
+          isWidthOfBottom as boolean,
+          measure.selfBottom,
+        );
+        updatedSize = newSize;
+        compareTarget = newProductSize;
+      }
+    } else {
+      if (currentTab === 'top') {
+        const [newSize, newProductSize] = checkMeasure(size, compareTarget, isWidthOfTop as boolean, measure.top);
+        updatedSize = newSize;
+        compareTarget = newProductSize;
+      } else {
+        const [newSize, newProductSize] = checkMeasure(size, compareTarget, isWidthOfBottom as boolean, measure.bottom);
+        updatedSize = newSize;
+        compareTarget = newProductSize;
+      }
+    }
+    console.log(isWidthOfTop, isWidthOfBottom, measure, updatedSize, compareTarget);
+    return updatedSize > compareTarget
+      ? `-${(updatedSize - compareTarget).toFixed(1)}`
+      : `+${(compareTarget - updatedSize).toFixed(1)}`;
+  };
+
+  const checkMeasure = (size: number, productSize: number, mySizeMeasure: boolean, compareMeasure: boolean) => {
+    if (mySizeMeasure && compareMeasure) {
+      return [size, productSize];
+    } else if (mySizeMeasure && !compareMeasure) {
+      return [size * 2, productSize];
+    } else if (!mySizeMeasure && compareMeasure) {
+      return [size / 2, productSize];
+    } else {
+      return [size, productSize];
+    }
   };
 
   const getMeasure = () => {
-    if (isSelfWrite) {
-      if (currentTab === 'top') {
-        return measure.selfTop ? '단면' : '둘레';
-      }
-      return measure.selfBottom ? '단면' : '둘레';
-    }
+    const { isWidthOfTop } = mySize.top;
+    const { isWidthOfBottom } = mySize.bottom;
     if (currentTab === 'top') {
-      return measure.top ? '단면' : '둘레';
+      return isWidthOfTop ? '단면' : '둘레';
+    } else {
+      return isWidthOfBottom ? '단면' : '둘레';
     }
-    return measure.bottom ? '단면' : '둘레';
   };
 
   return (

--- a/src/components/size-compare/Sizes.tsx
+++ b/src/components/size-compare/Sizes.tsx
@@ -21,7 +21,6 @@ function Sizes(props: SizesProps) {
 
   const calculateDifference = (key: keyof SizePropType, size: number) => {
     if (!productSizes) return;
-    console.log(key, size, productSizes[key]);
     let compareTarget = (productSizes[key] as unknown as number) || 0;
     let updatedSize = size;
     const { isWidthOfTop } = mySize.top;
@@ -59,7 +58,6 @@ function Sizes(props: SizesProps) {
         compareTarget = newProductSize;
       }
     }
-    console.log(isWidthOfTop, isWidthOfBottom, measure, updatedSize, compareTarget);
     return updatedSize > compareTarget
       ? `-${(updatedSize - compareTarget).toFixed(1)}`
       : `+${(compareTarget - updatedSize).toFixed(1)}`;

--- a/src/hooks/queries/useSaveProduct.ts
+++ b/src/hooks/queries/useSaveProduct.ts
@@ -64,12 +64,13 @@ export const useSaveProduct = () => {
     const { image, mallName, productName } = await getProductData(); // 상품 이미지 및 상품명
 
     const { productUrl, faviconUrl } = await getUrlData();
+    const size = sizeRecommended === 'nosize' || !sizeRecommended ? null : sizeRecommended;
     const body = {
       productUrl,
       image,
       mallName,
       productName: productName.slice(0, 36),
-      size: sizeRecommended || null,
+      size,
       isRecommend: sizeRecommended ? true : false,
       faviconUrl,
       userId: Number(userId),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "1.1",
+  "version": "1.2",
   "name": "온사이즈 OWNSIZE",
   "description": "쉽고 똑똑한 나만의 쇼핑 도우미, 온사이즈",
   "background": { "service_worker": "script/background.js" },

--- a/src/pages/Popup/size-write/index.tsx
+++ b/src/pages/Popup/size-write/index.tsx
@@ -99,8 +99,8 @@ function SizeWrite() {
         if (inputKey === 'size') {
           inputData.size = inputValue;
         } else {
-          const value = measure === '둘레' ? inputValue * 2 : inputValue;
-          inputData[inputKey] = parseFloat(value);
+          // const value = measure === '둘레' ? inputValue * 2 : inputValue;
+          inputData[inputKey] = parseFloat(inputValue);
         }
       });
 


### PR DESCRIPTION
## 이슈 넘버
- close #56
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->
- [x] 추천받은 사이즈가 'nosize'인 경우 or null인 경우 size = null , 사이즈 추천 결과가 존재하는 경우 sizeRecommended 값을 할당하여 body에 넘겨주도록 수정했습니다.
- [x] 수동입력 사이즈 비교 뷰 단면둘레 비교값 이슈 수정했습니다. 단면/단면, 단면/둘레, 둘레/단면, 둘레/둘레 경우를 처리했어요
```tsx
const checkMeasure = (size: number, productSize: number, mySizeMeasure: boolean, compareMeasure: boolean) => {
    if (mySizeMeasure && compareMeasure) {
      return [size, productSize];
    } else if (mySizeMeasure && !compareMeasure) {
      return [size * 2, productSize];
    } else if (!mySizeMeasure && compareMeasure) {
      return [size / 2, productSize];
    } else {
      return [size, productSize];
    }
  };
```


## Need Review
- ~ 부분 이렇게 구현했어요, 피드백 부탁해요!
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
